### PR TITLE
Solving some leftover todos in the code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,4 @@ run_server: ${BIN_DIR}server
 	cd ${BIN_DIR} && ./server 50
 
 run_client: ${BIN_DIR}client
-	cd ${BIN_DIR} && ./client user group 127.0.0.1 6789
+	cd ${BIN_DIR} && ./client user group localhost 6789

--- a/include/RW_Monitor.h
+++ b/include/RW_Monitor.h
@@ -12,9 +12,6 @@ class RW_Monitor
     pthread_cond_t ok_read, ok_write;           // Condition variables for reading and writing
     pthread_mutex_t lock;                       // Mutex lock for the incoming requests to wait
 
-    //std::unique_lock<std::mutex> lock;
-
-
     /**
      * Class constructor
      * Initializes num_readers and num_writers with 0 

--- a/include/constants.h
+++ b/include/constants.h
@@ -14,13 +14,14 @@
 #define SLEEP_TIME   10      // Time (in seconds) the client application waits between keep alive packets
 
 // Packet types
-#define PAK_DATA 1          // Message packet
-#define PAK_COMMAND 2       // Command packet
-#define PAK_KEEP_ALIVE 3    // Keep-Alive packet
-#define PAK_SERVER_MESSAGE 4  // A exclusive package sent by server
+#define PAK_DATA           1 // Message packet
+#define PAK_COMMAND        2 // Command packet
+#define PAK_KEEP_ALIVE     3 // Keep-Alive packet
+#define PAK_SERVER_MESSAGE 4 // Server message packet
 
 // Message types
 #define SERVER_MESSAGE 1 // Indicates a message sent by server (login or logout message)
-#define USER_MESSAGE 2   // Indicates a message sent by a user
+#define USER_MESSAGE   2 // Indicates a message sent by a user
+#define LOGIN_MESSAGE  3 // Login message containing group the user wants to log into
 
 #endif

--- a/include/constants.h
+++ b/include/constants.h
@@ -3,7 +3,7 @@
 
 // Server/Client related constants
 #define NAME_REGEX   "[A-Za-z][A-Za-z0-9\\.]{3,19}" // Regex for validating user and group names
-#define IP_REGEX     "[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}" // Regex for validating IP
+#define IP_REGEX     "([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})|localhost" // Regex for validating IP
 #define PORT_REGEX   "[0-9]+"   // Regex for validating port number
 #define HIST_PATH    "./hist/"  // Path to group history files
 #define SERVER_PORT  6789    // Port the remote server listens at

--- a/include/constants.h
+++ b/include/constants.h
@@ -4,6 +4,7 @@
 // Server/Client related constants
 #define NAME_REGEX   "[A-Za-z][A-Za-z0-9\\.]{3,19}" // Regex for validating user and group names
 #define IP_REGEX     "[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}" // Regex for validating IP
+#define PORT_REGEX   "[0-9]+"   // Regex for validating port number
 #define HIST_PATH    "./hist/"  // Path to group history files
 #define SERVER_PORT  6789    // Port the remote server listens at
 #define MAX_SESSIONS 2       // Maximum number of active sessions per user

--- a/include/data_types.h
+++ b/include/data_types.h
@@ -16,14 +16,6 @@ typedef struct __packet
 
 } packet;
 
-// Payload for a client login packet
-typedef struct __login_payload
-{
-    char username[21];  // Client username
-    char groupname[21]; // Groupname
-
-} login_payload;
-
 // Struct for recording a chat message, for storage in the history file
 typedef struct __message_record
 {

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -28,7 +28,7 @@ Client::Client(std::string username, std::string groupname, std::string server_i
     // Initialize values
     this->username = username;
     this->groupname = groupname;
-    this->server_ip = server_ip;
+    this->server_ip = !server_ip.compare("localhost")? "127.0.0.1" : server_ip;
     this->server_port = stoi(server_port);
     this->server_socket = -1;
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -21,7 +21,9 @@ Client::Client(std::string username, std::string groupname, std::string server_i
     if (!std::regex_match(server_ip, std::regex(IP_REGEX)))
         throw std::invalid_argument("Invalid IP format");
 
-    // TODO Validate port maybe?
+    // Validate port
+    if (!std::regex_match(server_port, std::regex(PORT_REGEX)))
+        throw std::invalid_argument("Invalid port format");
 
     // Initialize values
     this->username = username;

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -193,7 +193,7 @@ void Client::getMessages()
 
 void *Client::handleUserInput(void* arg)
 {
-    int payload_size;
+    message_record* message;
     
     // Flush stdin so no empty message is sent
     fflush(stdin);
@@ -212,16 +212,20 @@ void *Client::handleUserInput(void* arg)
 
             if (strlen(user_message) > 0) 
  	        {
+                // Compose message
+                message = CommunicationUtils::composeMessage(username, std::string(user_message), USER_MESSAGE);
+
                 // Request write rights
                 socket_monitor.requestWrite();
 
-                // Prepare message payload
-                char* payload = user_message + '\0';
-                payload_size = strlen(payload) + 1;
-                CommunicationUtils::sendPacket(server_socket, PAK_DATA, payload, payload_size);
+                // Send message to server
+                CommunicationUtils::sendPacket(server_socket, PAK_DATA, (char*)message, sizeof(*message) + message->length);
 
                 // Release write rights
                 socket_monitor.releaseWrite();
+
+                // Free composed message
+                free(message);
             }
 
         }

--- a/src/CommunicationUtils.cpp
+++ b/src/CommunicationUtils.cpp
@@ -38,16 +38,14 @@ message_record* CommunicationUtils::composeMessage(std::string sender_name, std:
     // Calculate total size of the message record struct
     int record_size = sizeof(message_record) + (message_content.length() + 1);
 
-    // TODO Save type
-
     // Create a record for the message
     message_record* msg = (message_record*)malloc(record_size); // Malloc memory
-    bzero((void*)msg, record_size);                                    // Initialize bytes to zero
+    bzero((void*)msg, record_size);                             // Initialize bytes to zero
     strcpy(msg->username,sender_name.c_str());                  // Copy sender name
     msg->timestamp = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()); // Current timestamp
-    msg->type = message_type;
+    msg->type = message_type;                                   // Update message type
     msg->length = message_content.length() + 1;                 // Update message length
-    strcpy((char*)msg->_message ,message_content.c_str());      // Copy message
+    strcpy((char*)msg->_message, message_content.c_str());      // Copy message
 
     //Return a pointer to it
     return msg;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -184,6 +184,9 @@ void *Server::handleConnection(void* arg)
         {
             case PAK_DATA:   // Data packet
 
+                // Decode received message into a message record
+                read_message = (message_record*)received_packet->_payload;
+
                 // If user and group still exist
                 if (user != NULL && group != NULL && !stop_issued)
                 {
@@ -191,7 +194,7 @@ void *Server::handleConnection(void* arg)
                     user->setLastSeen();
 
                     // Say message to the group
-                    user->say(received_packet->_payload, group->groupname);
+                    user->say(read_message->_message, group->groupname);
                 }
                 
                 break;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -238,16 +238,24 @@ void *Server::handleConnection(void* arg)
                 }
                 else
                 {
-                    // If user was not able to join group, refuse connection
-                    // TODO Send message in some type of standard struct
-                    sprintf(server_message, "%s %d", "Connection was refused due to exceding MAX_SESSIONS: ", MAX_SESSIONS);
-                    sendPacket(socket, PAK_COMMAND, server_message, sizeof(char)*strlen(server_message) + 1);
+                    // If user exceeds MAX_SESSIONS
+                    // Compose a message  of disconnection      
+                    message = "Connection was refused: exceeds MAX_SESSIONS (" + std::to_string(MAX_SESSIONS) + ")";
+                    
+                    // Compose message record
+                    read_message = CommunicationUtils::composeMessage(username,message, PAK_SERVER_MESSAGE);
+                    
+                    // Send message record to client
+                    sendPacket(socket, PAK_COMMAND, (char*)read_message, sizeof(*read_message) + read_message->length);
 
                     // Reject connection
                     close(socket);
 
                     // Free received argument pointer
                     free(arg);
+
+                    // Free composed message record
+                    free(read_message);
 
                     // Request write rights
                     threads_monitor.requestWrite();

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -161,7 +161,7 @@ void *Server::handleConnection(void* arg)
     int            read_bytes = -1;             // Number of bytes read from the message
     char           client_message[PACKET_MAX];  // Buffer for client message, maximum of PACKET_MAX bytes
     char           server_message[PACKET_MAX];  // Buffer for messages the server will send to the client, max PACKET_MAX bytes
-    login_payload* login_payload_buffer;        // Buffer for client login information
+    message_record* login_message;        // Buffer for client login information
     std::string    message;                     // User chat message
     std::string    username;                    // Connected user's name
     std::string    groupname;                   // Connected group's name
@@ -200,11 +200,12 @@ void *Server::handleConnection(void* arg)
                 break;
 
             case PAK_COMMAND:   // Command packet (login)
+
                 // Get user login information
-                login_payload_buffer = (login_payload*)received_packet->_payload;              
+                login_message = (message_record*)received_packet->_payload;              
 
                 // Try to join that group with this user
-                if (Group::joinByName(login_payload_buffer->username, login_payload_buffer->groupname, &user, &group, socket) != 0)
+                if (Group::joinByName(login_message->username, login_message->_message, &user, &group, socket) != 0)
                 {
                     // Update connected user and groupname
                     groupname = group->groupname;
@@ -294,7 +295,7 @@ void *Server::handleConnection(void* arg)
     if(errno == EAGAIN || errno == EWOULDBLOCK)
     {
         // If so, close the connection for good
-        // TODO Maybe inform client somehow?
+        // OBS: No point in sending message to client, application probably froze
         close(socket);
     }
 


### PR DESCRIPTION
- Validate port number received in client command line argument

- When exceeding MAX_SESSIONS, disconnect message is sent from the server inside a message_record structure

- Login messages sent from the client are now inside a message_record structure, with the username being the username field and the group name being the message content

- Messages sent from the client are now also inside a message_record structure

- login_payload struct becomes useless, and is removed

- Client application accepts 'localhost' as a command line argument for server IP